### PR TITLE
fix(Livewire): use `exceptFromTrimStrings` in `exceptFromRealtimeMapp…

### DIFF
--- a/src/Livewire/LivewireTrait.php
+++ b/src/Livewire/LivewireTrait.php
@@ -36,7 +36,7 @@ trait LivewireTrait
      */
     protected function exceptFromRealtimeMappingProperties(): array
     {
-        return [];
+        return $this->exceptFromTrimStrings();
     }
 
     /**


### PR DESCRIPTION
…ingProperties` for consistency